### PR TITLE
Fix websocket basic auth and add support for HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 	"dependencies": {
 		"@companion-module/base": "~2.0.3",
 		"bonjour-service": "^1.3.0",
+		"undici": "^8.8.0",
 		"ws": "^7.5.11"
 	},
 	"devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { InstanceBase, type SomeCompanionConfigField, type InstanceTypes } from '@companion-module/base'
+import type { SomeCompanionConfigField, InstanceTypes, JsonObject } from '@companion-module/base'
 
 export interface config {
 	bonjour_host: string
@@ -7,28 +7,13 @@ export interface config {
 	[key: string]: any
 }
 
-export interface secrets {
+export type secrets = JsonObject & {
 	password?: string
-	[key: string]: any
 }
 
 export interface GigaCoreInstanceTypes extends InstanceTypes {
 	config: config
 	secrets: secrets
-}
-
-export const instanceTypes: InstanceTypes = {
-	config: {} as config,
-	secrets: {},
-	actions: {},
-	feedbacks: {},
-	variables: {},
-}
-
-export interface InstanceBaseExt<TInstanceTypes extends InstanceTypes> extends InstanceBase<TInstanceTypes> {
-	config: TInstanceTypes['config']
-	UpdateVariablesValues(): void
-	InitVariables(): void
 }
 
 export const getConfigFields = (): SomeCompanionConfigField[] => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,9 +3,18 @@ import { InstanceBase, type SomeCompanionConfigField, type InstanceTypes } from 
 export interface config {
 	bonjour_host: string
 	host: string
-	password: string
 	gen1: boolean
 	[key: string]: any
+}
+
+export interface secrets {
+	password?: string
+	[key: string]: any
+}
+
+export interface GigaCoreInstanceTypes extends InstanceTypes {
+	config: config
+	secrets: secrets
 }
 
 export const instanceTypes: InstanceTypes = {
@@ -47,7 +56,7 @@ export const getConfigFields = (): SomeCompanionConfigField[] => {
 			default: false,
 		},
 		{
-			type: 'textinput',
+			type: 'secret-text',
 			id: 'password',
 			label: 'Password',
 			tooltip: 'Only provide a password when authentication is enabled on the device',

--- a/src/device.ts
+++ b/src/device.ts
@@ -52,7 +52,7 @@ export abstract class Device {
 	instance: ModuleInstance
 
 	/** Transport scheme in use for this device. Determined at connect time (see Gen2). */
-	protocol: 'http' | 'https' = 'http'
+	protected protocol: 'http' | 'https' = 'http'
 
 	/**
 	 * Shared dispatcher used for HTTPS requests. GigaCore devices may present a self-signed
@@ -111,15 +111,17 @@ export abstract class Device {
 	}
 
 	/**
-	 * fetch wrapper for device requests. When connected over HTTPS it injects the insecure
-	 * dispatcher so self-signed device certificates are accepted.
+	 * fetch wrapper for device requests. For HTTPS URLs it injects the insecure dispatcher so
+	 * self-signed device certificates are accepted.
+	 *
+	 * We deliberately use undici's own fetch + Agent rather than Node's global fetch: the
+	 * standalone undici version differs from the one bundled with Node, and feeding a standalone
+	 * Agent into the global fetch is unreliable across versions. Using the matched pair keeps the
+	 * dispatcher (which disables certificate validation) reliably honoured.
 	 */
 	protected async deviceFetch(url: string, options: UndiciRequestInit): Promise<UndiciResponse> {
 		const opts: UndiciRequestInit = { ...options }
-		if (this.protocol === 'https') {
-			// Use undici's own fetch + Agent so the dispatcher (which disables certificate
-			// validation for self-signed device certs) is actually honoured. Passing an Agent
-			// from this package to Node's built-in global fetch is unreliable across versions.
+		if (url.startsWith('https:')) {
 			opts.dispatcher = Device.insecureDispatcher
 		}
 		return undiciFetch(url, opts)

--- a/src/device.ts
+++ b/src/device.ts
@@ -1,5 +1,11 @@
 import ModuleInstance from './main.js'
 import { InstanceStatus, type CompanionVariableValue } from '@companion-module/base'
+import {
+	Agent,
+	fetch as undiciFetch,
+	type RequestInit as UndiciRequestInit,
+	type Response as UndiciResponse,
+} from 'undici'
 
 export interface MemberOf {
 	id: number
@@ -45,6 +51,15 @@ export abstract class Device {
 	password = ''
 	instance: ModuleInstance
 
+	/** Transport scheme in use for this device. Determined at connect time (see Gen2). */
+	protocol: 'http' | 'https' = 'http'
+
+	/**
+	 * Shared dispatcher used for HTTPS requests. GigaCore devices may present a self-signed
+	 * certificate, so certificate validation is disabled for device connections.
+	 */
+	private static insecureDispatcher = new Agent({ connect: { rejectUnauthorized: false } })
+
 	connected = false
 
 	nr_ports = 0
@@ -83,6 +98,46 @@ export abstract class Device {
 	protected authHeader(): string | undefined {
 		if (this.password === '') return undefined
 		return `Basic ${Buffer.from(`admin:${this.password}`).toString('base64')}`
+	}
+
+	/** Base HTTP(S) URL for the device, using the currently detected scheme. */
+	protected get httpBase(): string {
+		return `${this.protocol}://${this.host}`
+	}
+
+	/** Whether the WebSocket should connect over TLS (wss), matching the detected scheme. */
+	public get secure(): boolean {
+		return this.protocol === 'https'
+	}
+
+	/**
+	 * fetch wrapper for device requests. When connected over HTTPS it injects the insecure
+	 * dispatcher so self-signed device certificates are accepted.
+	 */
+	protected async deviceFetch(url: string, options: UndiciRequestInit): Promise<UndiciResponse> {
+		const opts: UndiciRequestInit = { ...options }
+		if (this.protocol === 'https') {
+			// Use undici's own fetch + Agent so the dispatcher (which disables certificate
+			// validation for self-signed device certs) is actually honoured. Passing an Agent
+			// from this package to Node's built-in global fetch is unreliable across versions.
+			opts.dispatcher = Device.insecureDispatcher
+		}
+		return undiciFetch(url, opts)
+	}
+
+	/** Extract a human-readable message from a thrown error, including undici's `cause`. */
+	protected errorMessage(error: unknown): string {
+		if (error instanceof Error) {
+			const cause = (error as { cause?: unknown }).cause
+			if (cause instanceof Error) {
+				return `${error.message} (${cause.message})`
+			}
+			if (cause && typeof cause === 'object' && 'code' in cause) {
+				return `${error.message} (${String((cause as { code: unknown }).code)})`
+			}
+			return error.message
+		}
+		return String(error)
 	}
 
 	public getNrPorts(): number {

--- a/src/device.ts
+++ b/src/device.ts
@@ -79,6 +79,12 @@ export abstract class Device {
 		this.password = password
 	}
 
+	/** Basic auth header for the device, or undefined when no password is set. */
+	protected authHeader(): string | undefined {
+		if (this.password === '') return undefined
+		return `Basic ${Buffer.from(`admin:${this.password}`).toString('base64')}`
+	}
+
 	public getNrPorts(): number {
 		return this.nr_ports
 	}

--- a/src/gen1.ts
+++ b/src/gen1.ts
@@ -40,14 +40,17 @@ export class Gen1 extends Device {
 
 	public initConnection(): void {
 		this.stopDevicePoll()
-		const requestHeaders = new Headers()
-		requestHeaders.set('Authorization', `Basic ${Buffer.from('admin:' + this.password).toString('base64')}`)
+		const requestHeaders: Record<string, string> = {}
+		const authHeader = this.authHeader()
+		if (authHeader) {
+			requestHeaders['Authorization'] = authHeader
+		}
 		const options = {
 			method: 'GET',
 			headers: requestHeaders,
 		}
 		this.log('debug', 'init connection')
-		fetch(`http://${this.host}/config/switchlegend`, options)
+		this.deviceFetch(`${this.httpBase}/config/switchlegend`, options)
 			.then(async (res) => {
 				if (res.status == 200) {
 					return res.text()
@@ -73,7 +76,7 @@ export class Gen1 extends Device {
 			})
 			.catch((error) => {
 				this.log('debug', 'failed connection')
-				this.log('debug', JSON.stringify(error))
+				this.log('debug', this.errorMessage(error))
 				this.updateStatus(InstanceStatus.ConnectionFailure)
 			})
 	}
@@ -144,12 +147,15 @@ export class Gen1 extends Device {
 		type: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | undefined,
 		params: any = undefined,
 	): void {
-		const url = `http://${this.host}/${cmd}`
-		const requestHeaders = new Headers()
+		const url = `${this.httpBase}/${cmd}`
+		const requestHeaders: Record<string, string> = {}
 		if (type && type !== 'GET') {
-			requestHeaders.set('Content-Type', 'application/x-www-form-urlencoded')
+			requestHeaders['Content-Type'] = 'application/x-www-form-urlencoded'
 		}
-		requestHeaders.set('Authorization', `Basic ${Buffer.from('admin:' + this.password).toString('base64')}`)
+		const authHeader = this.authHeader()
+		if (authHeader) {
+			requestHeaders['Authorization'] = authHeader
+		}
 
 		const options = {
 			method: type,
@@ -162,7 +168,7 @@ export class Gen1 extends Device {
 			this.log('debug', JSON.stringify(options))
 		}
 
-		fetch(url, options)
+		this.deviceFetch(url, options)
 			.then(async (res) => {
 				if (res.ok) {
 					if (!this.connected) {
@@ -196,7 +202,7 @@ export class Gen1 extends Device {
 				}
 			})
 			.catch((error) => {
-				this.log('debug', `CMD error: ${JSON.stringify(error)}`)
+				this.log('debug', `CMD error: ${this.errorMessage(error)}`)
 			})
 	}
 

--- a/src/gen1.ts
+++ b/src/gen1.ts
@@ -29,6 +29,15 @@ export class Gen1 extends Device {
 		super(instance)
 	}
 
+	/**
+	 * Gen1 devices always expect HTTP basic auth with the `admin` username, even when the
+	 * password is empty. Unlike the base implementation, we never omit the header — omitting it
+	 * makes the device reply 401.
+	 */
+	protected override authHeader(): string {
+		return `Basic ${Buffer.from(`admin:${this.password}`).toString('base64')}`
+	}
+
 	public async destroy(): Promise<void> {
 		this.stopDevicePoll()
 		this.updateStatus(InstanceStatus.Disconnected)

--- a/src/gen2.ts
+++ b/src/gen2.ts
@@ -81,6 +81,7 @@ export class Gen2 extends Device {
 			},
 			wsSubscriptions,
 			() => this.authHeader(),
+			() => this.secure,
 		)
 	}
 
@@ -94,53 +95,81 @@ export class Gen2 extends Device {
 
 	// Gen-2 specific functions
 	public initConnection(): void {
-		const headers = new Headers()
+		this.log('debug', 'init connection')
+		void this.detectAndConnect()
+	}
+
+	/**
+	 * Probe the device to determine which scheme it serves, then connect.
+	 * HTTP is tried first (still the most common case) and HTTPS is used as a fallback,
+	 * since newer GigaCore Gen2 firmware may serve https (possibly with a self-signed cert).
+	 */
+	private async detectAndConnect(): Promise<void> {
+		const headers: Record<string, string> = {}
 		const authHeader = this.authHeader()
 		if (authHeader) {
-			headers.set('Authorization', authHeader)
+			headers['Authorization'] = authHeader
 		}
-		const options = {
-			method: 'GET',
-			headers: headers,
+
+		const schemes: ('http' | 'https')[] = ['http', 'https']
+		let lastStatus: number | undefined
+		for (const scheme of schemes) {
+			this.protocol = scheme
+			try {
+				const res = await this.deviceFetch(`${this.httpBase}/api/device`, {
+					method: 'GET',
+					headers: headers,
+					// Bound each probe so a filtered/unreachable port doesn't hang the connect.
+					signal: AbortSignal.timeout(5000),
+				})
+				if (res.status === 200) {
+					this.log('debug', `Connected to ${this.host} over ${scheme}`)
+					this.applyDeviceInfo(await res.json())
+					return
+				}
+				if (res.status === 401 || res.status === 403) {
+					// The scheme is correct but the device rejected our credentials; no point in
+					// trying the other scheme.
+					this.log('error', `Authentication failed for ${this.host} over ${scheme} (status ${res.status})`)
+					this.updateStatus(InstanceStatus.ConnectionFailure, 'Authentication failed')
+					return
+				}
+				// Any other status (e.g. 400 when speaking plain http to an https-only device)
+				// means this scheme is wrong; fall through and try the next one.
+				lastStatus = res.status
+				this.log('debug', `Unexpected status ${res.status} from ${this.host} over ${scheme}, trying next scheme`)
+			} catch (error) {
+				this.log('debug', `Cannot reach ${this.host} over ${scheme}: ${this.errorMessage(error)}`)
+			}
 		}
-		this.log('debug', 'init connection')
-		fetch(`http://${this.host}/api/device`, options)
-			.then(async (res) => {
-				if (res.status == 200) {
-					return res.json()
-				}
-				throw new Error(this.safeStringify(res))
-			})
-			.then((data) => {
-				if (typeof data === 'object' && data !== null) {
-					this.log('debug', JSON.stringify(data))
-					const changedVariables: CompanionVariableValues = {}
-					if ('name' in data && typeof data.name === 'string') {
-						changedVariables[FixedVariableId.deviceName] = data.name
-					}
-					if ('description' in data && typeof data.description === 'string') {
-						changedVariables[FixedVariableId.description] = data.description
-					}
-					if ('serial' in data && typeof data.serial === 'string') {
-						changedVariables[FixedVariableId.serial] = data.serial
-					}
-					if ('mac_address' in data && typeof data.mac_address === 'string') {
-						changedVariables[FixedVariableId.macAddress] = data.mac_address
-					}
-					if ('model' in data && typeof data.model === 'string') {
-						changedVariables[FixedVariableId.model] = data.model
-					}
-					this.instance.setVariableValues(changedVariables)
-					this.initWebSocket()
-				} else {
-					this.updateStatus(InstanceStatus.ConnectionFailure)
-				}
-			})
-			.catch((error) => {
-				this.log('debug', `failed connection: ${JSON.stringify(error)}`)
-				this.log('debug', JSON.stringify(error))
-				this.updateStatus(InstanceStatus.ConnectionFailure)
-			})
+		this.log('error', `Failed to connect to ${this.host}${lastStatus ? ` (last status ${lastStatus})` : ''}`)
+		this.updateStatus(InstanceStatus.ConnectionFailure)
+	}
+
+	private applyDeviceInfo(data: unknown): void {
+		if (typeof data === 'object' && data !== null) {
+			this.log('debug', JSON.stringify(data))
+			const changedVariables: CompanionVariableValues = {}
+			if ('name' in data && typeof data.name === 'string') {
+				changedVariables[FixedVariableId.deviceName] = data.name
+			}
+			if ('description' in data && typeof data.description === 'string') {
+				changedVariables[FixedVariableId.description] = data.description
+			}
+			if ('serial' in data && typeof data.serial === 'string') {
+				changedVariables[FixedVariableId.serial] = data.serial
+			}
+			if ('mac_address' in data && typeof data.mac_address === 'string') {
+				changedVariables[FixedVariableId.macAddress] = data.mac_address
+			}
+			if ('model' in data && typeof data.model === 'string') {
+				changedVariables[FixedVariableId.model] = data.model
+			}
+			this.instance.setVariableValues(changedVariables)
+			this.initWebSocket()
+		} else {
+			this.updateStatus(InstanceStatus.ConnectionFailure)
+		}
 	}
 
 	public disconnect(msg: string): void {
@@ -193,12 +222,11 @@ export class Gen2 extends Device {
 	}
 
 	private sendCommand(cmd: string, type: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | undefined, params: Json): void {
-		const url = `http://${this.host}/api/${cmd}`
-		const requestHeaders = new Headers()
-		requestHeaders.set('Content-Type', 'application/json')
+		const url = `${this.httpBase}/api/${cmd}`
+		const requestHeaders: Record<string, string> = { 'Content-Type': 'application/json' }
 		const authHeader = this.authHeader()
 		if (authHeader) {
-			requestHeaders.set('Authorization', authHeader)
+			requestHeaders['Authorization'] = authHeader
 		}
 		const options = {
 			method: type,
@@ -211,7 +239,7 @@ export class Gen2 extends Device {
 			this.log('debug', JSON.stringify(options))
 		}
 
-		fetch(url, options)
+		this.deviceFetch(url, options)
 			.then(async (res) => {
 				if (res.ok) {
 					const contentType = res.headers.get('content-type')

--- a/src/gen2.ts
+++ b/src/gen2.ts
@@ -80,6 +80,7 @@ export class Gen2 extends Device {
 				ondisconnect: this.websocketDisconnect.bind(this),
 			},
 			wsSubscriptions,
+			() => this.authHeader(),
 		)
 	}
 
@@ -94,8 +95,9 @@ export class Gen2 extends Device {
 	// Gen-2 specific functions
 	public initConnection(): void {
 		const headers = new Headers()
-		if (this.password !== '') {
-			headers.set('Authorization', `Basic ${Buffer.from('admin:' + this.password).toString('base64')}`)
+		const authHeader = this.authHeader()
+		if (authHeader) {
+			headers.set('Authorization', authHeader)
 		}
 		const options = {
 			method: 'GET',
@@ -194,8 +196,9 @@ export class Gen2 extends Device {
 		const url = `http://${this.host}/api/${cmd}`
 		const requestHeaders = new Headers()
 		requestHeaders.set('Content-Type', 'application/json')
-		if (this.password !== '') {
-			requestHeaders.set('Authorization', `Basic ${Buffer.from('admin:' + this.password).toString('base64')}`)
+		const authHeader = this.authHeader()
+		if (authHeader) {
+			requestHeaders.set('Authorization', authHeader)
 		}
 		const options = {
 			method: type,

--- a/src/gen2.ts
+++ b/src/gen2.ts
@@ -80,8 +80,7 @@ export class Gen2 extends Device {
 				ondisconnect: this.websocketDisconnect.bind(this),
 			},
 			wsSubscriptions,
-			() => this.authHeader(),
-			() => this.secure,
+			() => ({ secure: this.secure, authHeader: this.authHeader() }),
 		)
 	}
 
@@ -114,22 +113,23 @@ export class Gen2 extends Device {
 		const schemes: ('http' | 'https')[] = ['http', 'https']
 		let lastStatus: number | undefined
 		for (const scheme of schemes) {
-			this.protocol = scheme
 			try {
-				const res = await this.deviceFetch(`${this.httpBase}/api/device`, {
+				const res = await this.deviceFetch(`${scheme}://${this.host}/api/device`, {
 					method: 'GET',
 					headers: headers,
 					// Bound each probe so a filtered/unreachable port doesn't hang the connect.
 					signal: AbortSignal.timeout(5000),
 				})
-				if (res.status === 200) {
-					this.log('debug', `Connected to ${this.host} over ${scheme}`)
-					this.applyDeviceInfo(await res.json())
-					return
-				}
-				if (res.status === 401 || res.status === 403) {
-					// The scheme is correct but the device rejected our credentials; no point in
-					// trying the other scheme.
+				if (res.status === 200 || res.status === 401 || res.status === 403) {
+					// A response we understand means this is the scheme the device speaks; commit it
+					// so subsequent requests (and the WebSocket) use it.
+					this.protocol = scheme
+					if (res.status === 200) {
+						this.log('debug', `Connected to ${this.host} over ${scheme}`)
+						this.applyDeviceInfo(await res.json())
+						return
+					}
+					// 401/403: correct scheme, rejected credentials — no point trying the other one.
 					this.log('error', `Authentication failed for ${this.host} over ${scheme} (status ${res.status})`)
 					this.updateStatus(InstanceStatus.ConnectionFailure, 'Authentication failed')
 					return

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-import { InstanceBase, InstanceStatus, type SomeCompanionConfigField, type InstanceTypes } from '@companion-module/base'
-import { type config, getConfigFields } from './config.js'
+import { InstanceBase, InstanceStatus, type SomeCompanionConfigField } from '@companion-module/base'
+import { type config, type secrets, type GigaCoreInstanceTypes, getConfigFields } from './config.js'
 import { getActions } from './actions.js'
 import { getPresets } from './presets.js'
 import { getVariables } from './variables.js'
@@ -9,8 +9,9 @@ import { Device } from './device.js'
 import { Gen1 } from './gen1.js'
 import { Gen2 } from './gen2.js'
 
-export default class ModuleInstance extends InstanceBase<InstanceTypes> {
+export default class ModuleInstance extends InstanceBase<GigaCoreInstanceTypes> {
 	config: config | undefined
+	secrets: secrets | undefined
 	public device?: Device
 
 	constructor(internal: unknown) {
@@ -18,11 +19,12 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 		this.log('debug', 'ModuleInstance constructor completed')
 	}
 
-	async init(config: config): Promise<void> {
+	async init(config: config, _isFirstInit: boolean, secrets: secrets): Promise<void> {
 		this.log('debug', 'init called')
 		try {
 			const old_host = this.getHostAddress()
 			this.config = config
+			this.secrets = secrets
 			const host = this.getHostAddress()
 			if (host) {
 				if (this.device && old_host !== host) {
@@ -39,7 +41,7 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 					return
 				}
 				this.updateStatus(InstanceStatus.Connecting)
-				this.device.setConfig(host, this.config && this.config.password ? this.config.password : '')
+				this.device.setConfig(host, this.secrets && this.secrets.password ? this.secrets.password : '')
 				this.device.initConnection()
 			} else {
 				this.log('warn', 'No host configured')
@@ -70,9 +72,9 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 		return getConfigFields()
 	}
 
-	async configUpdated(config: config): Promise<void> {
+	async configUpdated(config: config, secrets: secrets): Promise<void> {
 		this.updateStatus(InstanceStatus.Disconnected)
-		await this.init(config)
+		await this.init(config, false, secrets)
 	}
 
 	initVariables(): void {

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,4 +1,9 @@
-import type { CompanionStaticUpgradeScript, CompanionStaticUpgradeResult } from '@companion-module/base'
+import type {
+	CompanionStaticUpgradeScript,
+	CompanionStaticUpgradeProps,
+	CompanionStaticUpgradeResult,
+	CompanionUpgradeContext,
+} from '@companion-module/base'
 import type { config, secrets } from './config.js'
 
 export const upgradeScripts: CompanionStaticUpgradeScript<config, secrets>[] = [
@@ -9,11 +14,13 @@ export const upgradeScripts: CompanionStaticUpgradeScript<config, secrets>[] = [
 	 * authentication keeps working after the upgrade, and remove the plain-text copy
 	 * from the config store.
 	 */
-	((_context, props): CompanionStaticUpgradeResult<config, secrets> => {
-		const legacyConfig = props.config as (config & { password?: string }) | null
-		const legacyPassword = legacyConfig?.password
+	(
+		_context: CompanionUpgradeContext<config>,
+		props: CompanionStaticUpgradeProps<config, secrets>,
+	): CompanionStaticUpgradeResult<config, secrets> => {
+		const legacyPassword = props.config?.password
 
-		if (!legacyConfig || legacyPassword === undefined) {
+		if (props.config == null || legacyPassword === undefined) {
 			return {
 				updatedConfig: null,
 				updatedSecrets: null,
@@ -22,7 +29,7 @@ export const upgradeScripts: CompanionStaticUpgradeScript<config, secrets>[] = [
 			}
 		}
 
-		const updatedConfig = { ...legacyConfig }
+		const updatedConfig = { ...props.config }
 		delete updatedConfig.password
 
 		return {
@@ -34,5 +41,5 @@ export const upgradeScripts: CompanionStaticUpgradeScript<config, secrets>[] = [
 			updatedActions: [],
 			updatedFeedbacks: [],
 		}
-	}) as CompanionStaticUpgradeScript<config, secrets>,
+	},
 ]

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -1,13 +1,38 @@
-export const upgradeScripts = [
+import type { CompanionStaticUpgradeScript, CompanionStaticUpgradeResult } from '@companion-module/base'
+import type { config, secrets } from './config.js'
+
+export const upgradeScripts: CompanionStaticUpgradeScript<config, secrets>[] = [
 	/*
-	 * Place your upgrade scripts here
-	 * Remember that once it has been added it cannot be removed!
+	 * Upgrade script to move the password from the config store to the secrets store.
+	 * The password field was changed to a `secret-text` field, whose value lives in the
+	 * secrets store instead of the config store. Migrate any existing password so that
+	 * authentication keeps working after the upgrade, and remove the plain-text copy
+	 * from the config store.
 	 */
-	// function (context, props) {
-	// 	return {
-	// 		updatedConfig: null,
-	// 		updatedActions: [],
-	// 		updatedFeedbacks: [],
-	// 	}
-	// },
+	((_context, props): CompanionStaticUpgradeResult<config, secrets> => {
+		const legacyConfig = props.config as (config & { password?: string }) | null
+		const legacyPassword = legacyConfig?.password
+
+		if (!legacyConfig || legacyPassword === undefined) {
+			return {
+				updatedConfig: null,
+				updatedSecrets: null,
+				updatedActions: [],
+				updatedFeedbacks: [],
+			}
+		}
+
+		const updatedConfig = { ...legacyConfig }
+		delete updatedConfig.password
+
+		return {
+			updatedConfig,
+			updatedSecrets: {
+				...props.secrets,
+				password: legacyPassword,
+			},
+			updatedActions: [],
+			updatedFeedbacks: [],
+		}
+	}) as CompanionStaticUpgradeScript<config, secrets>,
 ]

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -38,10 +38,17 @@ export class WS {
 	subscriptions: Subscription[]
 
 	host: string
-	constructor(host: string, callbacks: WsCallbacks, subscriptions: Subscription[]) {
+	getAuthHeader?: () => string | undefined
+	constructor(
+		host: string,
+		callbacks: WsCallbacks,
+		subscriptions: Subscription[],
+		getAuthHeader?: () => string | undefined,
+	) {
 		this.host = host
 		this.callbacks = callbacks
 		this.subscriptions = subscriptions
+		this.getAuthHeader = getAuthHeader
 	}
 
 	private safeStringify(value: unknown): string {
@@ -67,7 +74,9 @@ export class WS {
 			this.ws.close(1000)
 			delete this.ws
 		}
-		this.ws = new WebSocket(url)
+		const authHeader = this.getAuthHeader?.()
+		const options = authHeader ? { headers: { Authorization: authHeader } } : undefined
+		this.ws = new WebSocket(url, options)
 
 		this.ws.onopen = this.websocketOpen.bind(this)
 		this.ws.onclose = this.websocketClose.bind(this)

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -39,16 +39,19 @@ export class WS {
 
 	host: string
 	getAuthHeader?: () => string | undefined
+	getSecure?: () => boolean
 	constructor(
 		host: string,
 		callbacks: WsCallbacks,
 		subscriptions: Subscription[],
 		getAuthHeader?: () => string | undefined,
+		getSecure?: () => boolean,
 	) {
 		this.host = host
 		this.callbacks = callbacks
 		this.subscriptions = subscriptions
 		this.getAuthHeader = getAuthHeader
+		this.getSecure = getSecure
 	}
 
 	private safeStringify(value: unknown): string {
@@ -68,15 +71,23 @@ export class WS {
 			delete this.reconnect_timer
 		}
 
-		const url = `ws://${this.host}/api/ws`
+		const secure = this.getSecure?.() ?? false
+		const url = `${secure ? 'wss' : 'ws'}://${this.host}/api/ws`
 
 		if (this.ws) {
 			this.ws.close(1000)
 			delete this.ws
 		}
 		const authHeader = this.getAuthHeader?.()
-		const options = authHeader ? { headers: { Authorization: authHeader } } : undefined
-		this.ws = new WebSocket(url, options)
+		const options: WebSocket.ClientOptions = {}
+		if (authHeader) {
+			options.headers = { Authorization: authHeader }
+		}
+		if (secure) {
+			// Devices may present a self-signed certificate.
+			options.rejectUnauthorized = false
+		}
+		this.ws = new WebSocket(url, Object.keys(options).length ? options : undefined)
 
 		this.ws.onopen = this.websocketOpen.bind(this)
 		this.ws.onclose = this.websocketClose.bind(this)

--- a/src/websocket.ts
+++ b/src/websocket.ts
@@ -28,6 +28,14 @@ export interface Subscription {
 	method: 'full' | 'changes'
 }
 
+/** Connection parameters resolved lazily at (re)connect time. */
+export interface WsConnectionInfo {
+	/** Connect over TLS (wss) rather than plain ws. */
+	secure: boolean
+	/** Authorization header value, or undefined when no authentication is configured. */
+	authHeader?: string
+}
+
 export class WS {
 	ws?: WebSocket
 	reconnect_timer?: NodeJS.Timeout
@@ -38,20 +46,17 @@ export class WS {
 	subscriptions: Subscription[]
 
 	host: string
-	getAuthHeader?: () => string | undefined
-	getSecure?: () => boolean
+	getConnection: () => WsConnectionInfo
 	constructor(
 		host: string,
 		callbacks: WsCallbacks,
 		subscriptions: Subscription[],
-		getAuthHeader?: () => string | undefined,
-		getSecure?: () => boolean,
+		getConnection: () => WsConnectionInfo,
 	) {
 		this.host = host
 		this.callbacks = callbacks
 		this.subscriptions = subscriptions
-		this.getAuthHeader = getAuthHeader
-		this.getSecure = getSecure
+		this.getConnection = getConnection
 	}
 
 	private safeStringify(value: unknown): string {
@@ -71,14 +76,13 @@ export class WS {
 			delete this.reconnect_timer
 		}
 
-		const secure = this.getSecure?.() ?? false
+		const { secure, authHeader } = this.getConnection()
 		const url = `${secure ? 'wss' : 'ws'}://${this.host}/api/ws`
 
 		if (this.ws) {
 			this.ws.close(1000)
 			delete this.ws
 		}
-		const authHeader = this.getAuthHeader?.()
 		const options: WebSocket.ClientOptions = {}
 		if (authHeader) {
 			options.headers = { Authorization: authHeader }

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,6 +657,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     typescript: "npm:^6.0.2"
     typescript-eslint: "npm:^8.58.1"
+    undici: "npm:^8.8.0"
     ws: "npm:^7.5.11"
   languageName: unknown
   linkType: soft
@@ -2017,6 +2018,13 @@ __metadata:
   version: 7.18.2
   resolution: "undici-types@npm:7.18.2"
   checksum: 10c0/85a79189113a238959d7a647368e4f7c5559c3a404ebdb8fc4488145ce9426fcd82252a844a302798dfc0e37e6fb178ff481ed03bc4caf634c5757d9ef43521d
+  languageName: node
+  linkType: hard
+
+"undici@npm:^8.8.0":
+  version: 8.8.0
+  resolution: "undici@npm:8.8.0"
+  checksum: 10c0/6ee51e6b814b67e212b19349c38657be988d878ca669ccf2ad33f0ebbb0d83e851aa57554b6ce3c6668a9a4df3010fb6a6af7bd28692ade911083ef376a3a75d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Fix WebSocket basic auth, support HTTPS/self-signed certs, and move password to secrets store

### Summary

This branch fixes basic authentication on the WebSocket connection and adds support for GigaCore Gen2 devices that serve HTTPS (including self-signed certificates). It also migrates the device password from the plain-text config store into Companion's dedicated secrets store, and refactors the shared device connection logic.

### What changed

**WebSocket basic auth fix**
- The WebSocket connection now sends the `Authorization: Basic` header, so authenticated devices no longer reject the socket. Connection parameters (scheme + auth header) are resolved lazily at each (re)connect via a `getConnection()` callback, so credentials and scheme stay current across reconnects.

**HTTPS + self-signed certificate support (Gen2)**
- Gen2 now probes the device at connect time, trying `http` first and falling back to `https`, then commits the detected scheme for all subsequent HTTP requests **and** the WebSocket (`ws`/`wss`).
- `401`/`403` are treated as "correct scheme, bad credentials" and reported as an authentication failure instead of falling through to the other scheme.
- Each probe is bounded with a 5s timeout so a filtered/unreachable port can't hang the connect.
- HTTPS requests use an `undici` `Agent` with `rejectUnauthorized: false`, and the WebSocket uses `rejectUnauthorized: false`, to accept self-signed device certificates. `undici`'s standalone `fetch` + `Agent` pair is used deliberately (rather than Node's global `fetch`) so the dispatcher reliably disables cert validation.

**Password moved to secrets store**
- The password config field changed from `textinput` to `secret-text`; its value now lives in the secrets store rather than the config store.
- New `GigaCoreInstanceTypes` / `secrets` types; `init`/`configUpdated` now receive and thread through `secrets`.
- Added an upgrade script that migrates any existing plain-text password from config into secrets and removes the plain-text copy.

**Refactor & cleanup**
- Shared connection helpers hoisted into the `Device` base class: `authHeader()`, `httpBase`, `secure`, `deviceFetch()`, and `errorMessage()` (which unwraps undici's `cause`). Gen1 and Gen2 now use these instead of duplicating header/URL construction.
- Improved error logging to surface underlying network error causes/codes instead of `JSON.stringify` on error objects.

### Dependencies
- Added `undici` `^8.8.0`.

